### PR TITLE
Sync keyd and kanata timeout settings

### DIFF
--- a/kanata/kanata.kbd
+++ b/kanata/kanata.kbd
@@ -21,11 +21,11 @@
 (defvar
   ;; Timing variables for home row mods and chords
   streak-count 3       ;; Number of keys to consider a "typing streak"
-  streak-time 450      ;; Max time (ms) window to maintain a streak
+  streak-time 500      ;; Max time (ms) window to maintain a streak
   tap-timeout 200      ;; Max time (ms) for a tap to be recognized
   hold-timeout 300     ;; Time (ms) to wait before a hold is recognized
   chord-timeout 50     ;; Window (ms) to press keys together for a chord
-  one-shot-timeout 450 ;; Timeout (ms) for one-shot modifiers/layers
+  one-shot-timeout 500 ;; Timeout (ms) for one-shot modifiers/layers
 )
 
 ;; Templates to simplify complex key behaviors

--- a/keyd/default.conf
+++ b/keyd/default.conf
@@ -6,6 +6,11 @@
 # - 'Fumbol' layer for numbers, function keys, and symbols.
 # - Chords for common keys like Escape, Backspace, Tab, and Enter.
 
+[global]
+
+chord_timeout = 50
+oneshot_timeout = 500
+
 [ids]
 
 # Match all keyboard devices by default
@@ -15,9 +20,9 @@
 
 # Home Row Modifiers
 # The following complex mapping is used for home row mods:
-# a = overloadi(a, timeout(overloadt2(meta, a, 200), 500, a), 150)
+# a = overloadi(a, timeout(overloadt2(meta, a, 200), 500, a), 250)
 # 
-# 1. `overloadi(key, ..., 150)`: If typed fast (within 150ms of another key), 
+# 1. `overloadi(key, ..., 250)`: If typed fast (within 250ms of another key), 
 #    immediately emit 'key'. This prevents mods from triggering during normal typing.
 # 2. `timeout(..., 500, key)`: If held for more than 500ms without other keys, 
 #    it defaults to repeating the 'key' (auto-repeat).
@@ -25,25 +30,25 @@
 #    it acts as 'mod'. Otherwise, it emits 'key' on tap. This ensures the modifier 
 #    triggers only if another key is pressed while it is held.
 
-a = overloadi(a, timeout(overloadt2(meta, a, 200), 500, a), 150)
-s = overloadi(s, timeout(overloadt2(alt, s, 200), 500, s), 150)
-d = overloadi(d, timeout(overloadt2(shift, d, 200), 500, d), 150)
-f = overloadi(f, timeout(overloadt2(control, f, 200), 500, f), 150)
-j = overloadi(j, timeout(overloadt2(control, j, 200), 500, j), 150)
-k = overloadi(k, timeout(overloadt2(shift, k, 200), 500, k), 150)
-l = overloadi(l, timeout(overloadt2(alt, l, 200), 500, l), 150)
-semicolon = overloadi(semicolon, timeout(overloadt2(meta, semicolon, 200), 500, semicolon), 150)
+a = overloadi(a, timeout(overloadt2(meta, a, 200), 500, a), 250)
+s = overloadi(s, timeout(overloadt2(alt, s, 200), 500, s), 250)
+d = overloadi(d, timeout(overloadt2(shift, d, 200), 500, d), 250)
+f = overloadi(f, timeout(overloadt2(control, f, 200), 500, f), 250)
+j = overloadi(j, timeout(overloadt2(control, j, 200), 500, j), 250)
+k = overloadi(k, timeout(overloadt2(shift, k, 200), 500, k), 250)
+l = overloadi(l, timeout(overloadt2(alt, l, 200), 500, l), 250)
+semicolon = overloadi(semicolon, timeout(overloadt2(meta, semicolon, 200), 500, semicolon), 250)
 
 # Bottom Row Modifiers
-z = overloadi(z, timeout(overloadt2(control, z, 200), 500, z), 150)
-x = overloadi(x, timeout(overloadt2(altgr, x, 200), 500, x), 150)
-v = overloadi(v, timeout(overloadt2(fumbol, v, 200), 500, v), 150)
-m = overloadi(m, timeout(overloadt2(fumbol, m, 200), 500, m), 150)
-dot = overloadi(dot, timeout(overloadt2(altgr, dot, 200), 500, dot), 150)
-slash = overloadi(slash, timeout(overloadt2(control, slash, 200), 500, slash), 150)
+z = overloadi(z, timeout(overloadt2(control, z, 200), 500, z), 250)
+x = overloadi(x, timeout(overloadt2(altgr, x, 200), 500, x), 250)
+v = overloadi(v, timeout(overloadt2(fumbol, v, 200), 500, v), 250)
+m = overloadi(m, timeout(overloadt2(fumbol, m, 200), 500, m), 250)
+dot = overloadi(dot, timeout(overloadt2(altgr, dot, 200), 500, dot), 250)
+slash = overloadi(slash, timeout(overloadt2(control, slash, 200), 500, slash), 250)
 
 # Space is overloaded to the 'extend' layer
-space = overloadi(space, timeout(overloadt2(extend, space, 200), 500, space), 150)
+space = overloadi(space, timeout(overloadt2(extend, space, 200), 500, space), 250)
 
 # Chords (Simultaneous key presses)
 w+e = esc
@@ -133,26 +138,26 @@ b = f11
 n = f12
 
 # Numbers with Home Row Mods
-a = overloadi(1, timeout(overloadt2(meta, 1, 200), 500, 1), 150)
-s = overloadi(2, timeout(overloadt2(alt, 2, 200), 500, 2), 150)
-d = overloadi(3, timeout(overloadt2(shift, 3, 200), 500, 3), 150)
-f = overloadi(4, timeout(overloadt2(control, 4, 200), 500, 4), 150)
+a = overloadi(1, timeout(overloadt2(meta, 1, 200), 500, 1), 250)
+s = overloadi(2, timeout(overloadt2(alt, 2, 200), 500, 2), 250)
+d = overloadi(3, timeout(overloadt2(shift, 3, 200), 500, 3), 250)
+f = overloadi(4, timeout(overloadt2(control, 4, 200), 500, 4), 250)
 g = 5
 h = 6
-j = overloadi(7, timeout(overloadt2(control, 7, 200), 500, 7), 150)
-k = overloadi(8, timeout(overloadt2(shift, 8, 200), 500, 8), 150)
-l = overloadi(9, timeout(overloadt2(alt, 9, 200), 500, 9), 150)
-semicolon = overloadi(0, timeout(overloadt2(meta, 0, 200), 500, 0), 150)
+j = overloadi(7, timeout(overloadt2(control, 7, 200), 500, 7), 250)
+k = overloadi(8, timeout(overloadt2(shift, 8, 200), 500, 8), 250)
+l = overloadi(9, timeout(overloadt2(alt, 9, 200), 500, 9), 250)
+semicolon = overloadi(0, timeout(overloadt2(meta, 0, 200), 500, 0), 250)
 
 # Symbols and Punctuations
-z = overloadi(102nd, timeout(overloadt2(control, 102nd, 200), 500, 102nd), 150)
-x = overloadi(grave, timeout(overloadt2(altgr, grave, 200), 500, grave), 150)
+z = overloadi(102nd, timeout(overloadt2(control, 102nd, 200), 500, 102nd), 250)
+x = overloadi(grave, timeout(overloadt2(altgr, grave, 200), 500, grave), 250)
 c = minus
 v = equal
 m = apostrophe
 comma = leftbrace
-dot = overloadi(rightbrace, timeout(overloadt2(altgr, rightbrace, 200), 500, rightbrace), 150)
-slash = overloadi(backslash, timeout(overloadt2(control, backslash, 200), 500, backslash), 150)
+dot = overloadi(rightbrace, timeout(overloadt2(altgr, rightbrace, 200), 500, rightbrace), 250)
+slash = overloadi(backslash, timeout(overloadt2(control, backslash, 200), 500, backslash), 250)
 
 # Fumbol Chords
 w+e = esc


### PR DESCRIPTION
## Summary
- align chord timeout to 50ms between keyd and kanata
- align one-shot timeout to 500ms between keyd and kanata
- increase kanata streak-time from 450ms to 500ms
- increase keyd overloadi windows from 150ms to 250ms for home-row and related mappings

## Why
These changes keep behavior consistent between the keyd and kanata configurations while making typing streak and overload timing more forgiving.