### PR TITLE
Decrease chord timeout to 35ms

### DIFF
--- a/kanata/kanata.kbd
+++ b/kanata/kanata.kbd
@@ -21,7 +21,7 @@
 (defvar
   ;; Timing variables for home row mods and chords
   streak-count 3       ;; Number of keys to consider a "typing streak"
-  streak-time 500      ;; Max time (ms) window to maintain a streak
+  streak-time 600      ;; Max time (ms) window to maintain a streak
   tap-timeout 200      ;; Max time (ms) for a tap to be recognized
   hold-timeout 300     ;; Time (ms) to wait before a hold is recognized
   chord-timeout 35     ;; Window (ms) to press keys together for a chord

--- a/kanata/kanata.kbd
+++ b/kanata/kanata.kbd
@@ -24,7 +24,7 @@
   streak-time 500      ;; Max time (ms) window to maintain a streak
   tap-timeout 200      ;; Max time (ms) for a tap to be recognized
   hold-timeout 300     ;; Time (ms) to wait before a hold is recognized
-  chord-timeout 50     ;; Window (ms) to press keys together for a chord
+  chord-timeout 35     ;; Window (ms) to press keys together for a chord
   one-shot-timeout 500 ;; Timeout (ms) for one-shot modifiers/layers
 )
 

--- a/keyd/default.conf
+++ b/keyd/default.conf
@@ -8,7 +8,7 @@
 
 [global]
 
-chord_timeout = 50
+chord_timeout = 35
 oneshot_timeout = 500
 
 [ids]

--- a/keyd/default.conf
+++ b/keyd/default.conf
@@ -20,9 +20,9 @@ oneshot_timeout = 500
 
 # Home Row Modifiers
 # The following complex mapping is used for home row mods:
-# a = overloadi(a, timeout(overloadt2(meta, a, 200), 500, a), 250)
+# a = overloadi(a, timeout(overloadt2(meta, a, 200), 500, a), 200)
 # 
-# 1. `overloadi(key, ..., 250)`: If typed fast (within 250ms of another key), 
+# 1. `overloadi(key, ..., 200)`: If typed fast (within 200ms of another key), 
 #    immediately emit 'key'. This prevents mods from triggering during normal typing.
 # 2. `timeout(..., 500, key)`: If held for more than 500ms without other keys, 
 #    it defaults to repeating the 'key' (auto-repeat).
@@ -30,25 +30,25 @@ oneshot_timeout = 500
 #    it acts as 'mod'. Otherwise, it emits 'key' on tap. This ensures the modifier 
 #    triggers only if another key is pressed while it is held.
 
-a = overloadi(a, timeout(overloadt2(meta, a, 200), 500, a), 250)
-s = overloadi(s, timeout(overloadt2(alt, s, 200), 500, s), 250)
-d = overloadi(d, timeout(overloadt2(shift, d, 200), 500, d), 250)
-f = overloadi(f, timeout(overloadt2(control, f, 200), 500, f), 250)
-j = overloadi(j, timeout(overloadt2(control, j, 200), 500, j), 250)
-k = overloadi(k, timeout(overloadt2(shift, k, 200), 500, k), 250)
-l = overloadi(l, timeout(overloadt2(alt, l, 200), 500, l), 250)
-semicolon = overloadi(semicolon, timeout(overloadt2(meta, semicolon, 200), 500, semicolon), 250)
+a = overloadi(a, timeout(overloadt2(meta, a, 200), 500, a), 200)
+s = overloadi(s, timeout(overloadt2(alt, s, 200), 500, s), 200)
+d = overloadi(d, timeout(overloadt2(shift, d, 200), 500, d), 200)
+f = overloadi(f, timeout(overloadt2(control, f, 200), 500, f), 200)
+j = overloadi(j, timeout(overloadt2(control, j, 200), 500, j), 200)
+k = overloadi(k, timeout(overloadt2(shift, k, 200), 500, k), 200)
+l = overloadi(l, timeout(overloadt2(alt, l, 200), 500, l), 200)
+semicolon = overloadi(semicolon, timeout(overloadt2(meta, semicolon, 200), 500, semicolon), 200)
 
 # Bottom Row Modifiers
-z = overloadi(z, timeout(overloadt2(control, z, 200), 500, z), 250)
-x = overloadi(x, timeout(overloadt2(altgr, x, 200), 500, x), 250)
-v = overloadi(v, timeout(overloadt2(fumbol, v, 200), 500, v), 250)
-m = overloadi(m, timeout(overloadt2(fumbol, m, 200), 500, m), 250)
-dot = overloadi(dot, timeout(overloadt2(altgr, dot, 200), 500, dot), 250)
-slash = overloadi(slash, timeout(overloadt2(control, slash, 200), 500, slash), 250)
+z = overloadi(z, timeout(overloadt2(control, z, 200), 500, z), 200)
+x = overloadi(x, timeout(overloadt2(altgr, x, 200), 500, x), 200)
+v = overloadi(v, timeout(overloadt2(fumbol, v, 200), 500, v), 200)
+m = overloadi(m, timeout(overloadt2(fumbol, m, 200), 500, m), 200)
+dot = overloadi(dot, timeout(overloadt2(altgr, dot, 200), 500, dot), 200)
+slash = overloadi(slash, timeout(overloadt2(control, slash, 200), 500, slash), 200)
 
 # Space is overloaded to the 'extend' layer
-space = overloadi(space, timeout(overloadt2(extend, space, 200), 500, space), 250)
+space = overloadi(space, timeout(overloadt2(extend, space, 200), 500, space), 200)
 
 # Chords (Simultaneous key presses)
 w+e = esc
@@ -138,26 +138,26 @@ b = f11
 n = f12
 
 # Numbers with Home Row Mods
-a = overloadi(1, timeout(overloadt2(meta, 1, 200), 500, 1), 250)
-s = overloadi(2, timeout(overloadt2(alt, 2, 200), 500, 2), 250)
-d = overloadi(3, timeout(overloadt2(shift, 3, 200), 500, 3), 250)
-f = overloadi(4, timeout(overloadt2(control, 4, 200), 500, 4), 250)
+a = overloadi(1, timeout(overloadt2(meta, 1, 200), 500, 1), 200)
+s = overloadi(2, timeout(overloadt2(alt, 2, 200), 500, 2), 200)
+d = overloadi(3, timeout(overloadt2(shift, 3, 200), 500, 3), 200)
+f = overloadi(4, timeout(overloadt2(control, 4, 200), 500, 4), 200)
 g = 5
 h = 6
-j = overloadi(7, timeout(overloadt2(control, 7, 200), 500, 7), 250)
-k = overloadi(8, timeout(overloadt2(shift, 8, 200), 500, 8), 250)
-l = overloadi(9, timeout(overloadt2(alt, 9, 200), 500, 9), 250)
-semicolon = overloadi(0, timeout(overloadt2(meta, 0, 200), 500, 0), 250)
+j = overloadi(7, timeout(overloadt2(control, 7, 200), 500, 7), 200)
+k = overloadi(8, timeout(overloadt2(shift, 8, 200), 500, 8), 200)
+l = overloadi(9, timeout(overloadt2(alt, 9, 200), 500, 9), 200)
+semicolon = overloadi(0, timeout(overloadt2(meta, 0, 200), 500, 0), 200)
 
 # Symbols and Punctuations
-z = overloadi(102nd, timeout(overloadt2(control, 102nd, 200), 500, 102nd), 250)
-x = overloadi(grave, timeout(overloadt2(altgr, grave, 200), 500, grave), 250)
+z = overloadi(102nd, timeout(overloadt2(control, 102nd, 200), 500, 102nd), 200)
+x = overloadi(grave, timeout(overloadt2(altgr, grave, 200), 500, grave), 200)
 c = minus
 v = equal
 m = apostrophe
 comma = leftbrace
-dot = overloadi(rightbrace, timeout(overloadt2(altgr, rightbrace, 200), 500, rightbrace), 250)
-slash = overloadi(backslash, timeout(overloadt2(control, backslash, 200), 500, backslash), 250)
+dot = overloadi(rightbrace, timeout(overloadt2(altgr, rightbrace, 200), 500, rightbrace), 200)
+slash = overloadi(backslash, timeout(overloadt2(control, backslash, 200), 500, backslash), 200)
 
 # Fumbol Chords
 w+e = esc


### PR DESCRIPTION
Decreases the chord timeout to 35 milliseconds across Kanata and keyd configurations to reduce accidental chord misfires during fast typing/rolls (such as the `io` bigram).

Closes #26